### PR TITLE
Including a readme with system requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Mike's out of excuses
+
+## Requirements
+
+------------
+* [virtualBox](https://www.virtualbox.org/wiki/Downloads) >= 4.3.x
+* [vagrant](http://downloads.vagrantup.com/) >= 1.7.x
+* [ansible](http://docs.ansible.com/ansible/intro_installation.html) >= 1.9.x

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,22 +1,15 @@
 #!/bin/bash
 
 set -e
-
 # Get Pantheon's Command Line Tool, terminus.
-sudo curl https://github.com/pantheon-systems/cli/releases/download/0.5.5/terminus.phar -L -o /usr/local/bin/terminus && sudo chmod +x /usr/local/bin/terminus
+sudo curl https://github.com/pantheon-systems/cli/releases/download/0.8.1/terminus.phar -L -o /usr/local/bin/terminus
+sudo chmod +x /usr/local/bin/terminus
 
 # Log into terminus.
 terminus auth login $PANTHEON_EMAIL --password=$PANTHEON_PASSWORD
 
 # Clone deployment repository.
-expect <<delim
-  set timeout 60
-  eval spawn git clone $PANTHEON_CODE pantheon
-  set prompt ":|#|\\\$"
-  interact -o -nobuffer -re $prompt return
-  send "$PANTHEON_PASSWORD\r"
-expect eof
-delim
+git clone $PANTHEON_CODE pantheon
 
 # Set variables
 path=$(dirname "$0")
@@ -24,11 +17,10 @@ base=$(cd $path/.. && pwd)
 pantheon=$base/pantheon
 git="( $base/pantheon && git $git_flags)"
 
-# Build the deployment artifact...
-sudo rm -f $base/cnf/settings.php
+# Build the deployment artifact.
+sudo rm $base/cnf/settings.php
+sudo rm -Rf $base/www/sites/default
 mv $base/cnf/pantheon.settings.php $base/cnf/settings.php
-
-# Use this bit only if you are using my method of using Composer.
 $base/bin/rootcanal --prod
 
 # Add deployment artifact to the repository.

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
 
 dependencies:
   pre:
+    - composer config --global github-oauth.github.com $GITHUB_TOKEN
     - cp $HOME/$CIRCLE_PROJECT_REPONAME/cnf/circle.conf /etc/apache2/sites-available/default
     - sudo sed -e "s?%HOME%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
     - sudo sed -e "s?%PROJECT_DIR%?www?g" --in-place /etc/apache2/sites-available/default
@@ -20,7 +21,7 @@ dependencies:
 test:
   override:
       - bin/behat
-      
+
 deployment:
   pantheon:
     branch: master
@@ -29,5 +30,5 @@ deployment:
       - composer install --no-dev --no-scripts
       - bin/deploy
       - mysqldump -u ubuntu circle_test > pantheon.sql
-      - terminus drush sqlc < pantheon.sql --site=de-no-excuses --env=dev
-      - terminus site clear-caches --site=de-no-excuses --env=dev
+      - terminus site clear-cache --site=mikes-out-of-excuses --env=dev
+      - terminus drush sqlc < pantheon.sql --site=mikes-out-of-excuses --env=dev


### PR DESCRIPTION
With this update, you need to create a github token on github, copy it and save it to an environment variable on your circle ci settings called: GITHUB_TOKEN
![github_token](https://cloud.githubusercontent.com/assets/1851632/10474435/917bd574-71eb-11e5-96b8-52aa2edb5b9b.png)

I am also noticing that I occasionally get this error on circle ci caused by terminus:
![terminus_error](https://cloud.githubusercontent.com/assets/1851632/10474444/beb30c10-71eb-11e5-8f56-57cb3c26e559.png)
I believe pantheon is working to resolve such occasional errors, but for now I need to run the tests again without the cache.

This run passes on circle: https://circleci.com/gh/craychee/no-excuses/24